### PR TITLE
Revamped stopping capture logic

### DIFF
--- a/CaptureIT/Private/Import-ScreenCaptureClass.ps1
+++ b/CaptureIT/Private/Import-ScreenCaptureClass.ps1
@@ -60,8 +60,8 @@ namespace ScreenShotDemo
       // get the size 
       User32.RECT windowRect = new User32.RECT(); 
       User32.GetWindowRect(handle,ref windowRect); 
-      int width = windowRect.right - windowRect.left; 
-      int height = windowRect.bottom - windowRect.top; 
+      int width = windowRect.right - windowRect.left + 1; 
+      int height = windowRect.bottom - windowRect.top + 1; 
       // create a device context we can copy to 
       IntPtr hdcDest = GDI32.CreateCompatibleDC(hdcSrc); 
       // create a bitmap we can copy it to, 
@@ -88,7 +88,7 @@ namespace ScreenShotDemo
     /// <param name="filename"></param> 
     /// <param name="format"></param> 
     public void CaptureActiveWindowToFile(string filename, ImageFormat format) 
-    { 
+    {
       Image img = CaptureActiveWindow(); 
       img.Save(filename,format); 
     } 

--- a/CaptureIT/Public/ConvertTo-Gif.ps1
+++ b/CaptureIT/Public/ConvertTo-Gif.ps1
@@ -31,18 +31,23 @@ function ConvertTo-Gif {
         ]
         [string]$FilePath
     )
-    
-    $ScreenShotImages = (Get-ChildItem -Path "$env:TEMP\CaptureIT\" -Depth 1).FullName
 
-    try{
-        if (-not(Get-ChildItem -Path $FilePath -ErrorAction SilentlyContinue)){
+    if (-not(Get-ChildItem -Path "$env:TEMP\CaptureIT\" -ErrorAction SilentlyContinue)) {
+        Write-Error -Message 'There are no screenshots available to create GIF from'
+        exit -1
+    }
+
+    $ScreenShotImages = (Get-ChildItem -Path "$env:TEMP\CaptureIT\").FullName
+
+    try {
+        if (-not(Get-ChildItem -Path $FilePath -ErrorAction SilentlyContinue)) {
             New-Item -Path $FilePath -Force
         }
     }
-    catch{
+    catch {
         Write-Error -ErrorRecord $Error[0] -RecommendedAction 'Ensure that you have access to create files in the provided filepath location'
     }
-    
+
     try {
         Write-Verbose -Message 'Creating GitWriter object'
 
@@ -54,17 +59,12 @@ function ConvertTo-Gif {
 
             $imageObject = $null
         }
-        
+
         $GifWriterObject.Dispose()
-         
-        $returnObject = @{
-            Gif                = $FilePath
-            'Screenshot Count' = $ScreenShotImages.Count
-        }
-        Write-Output -InputObject $returnObject
+        Write-Output $True
     }
     catch {
         Write-Error -ErrorRecord $Error[0]
         exit -1
-    }    
+    }
 }

--- a/CaptureIT/Public/Start-ActiveWindowCapture.ps1
+++ b/CaptureIT/Public/Start-ActiveWindowCapture.ps1
@@ -40,6 +40,7 @@ function Start-ActiveWindowCapture {
         [string]$ImageType = 'png'
     )
 
+    begin {
     Write-Verbose -Message 'Starting Active Window Capture'
 
     try {
@@ -49,7 +50,8 @@ function Start-ActiveWindowCapture {
     catch {
         Write-Error -ErrorRecord $Error[0]
     }
-
+    }
+    process {
     $varCount = 1
     try {
         if ($pscmdlet.ShouldProcess("Active Window", "Capturing")) {
@@ -77,7 +79,25 @@ function Start-ActiveWindowCapture {
         Write-Error -ErrorRecord $Error[0]
         exit -1
     }
-
+    }
+    end {
     Write-Verbose -Message 'Captured Active Window successfully'
     Write-Output $true
+}                       ConvertTo-Gif -FilePath $script:GifFilePath
+                        Write-Progress -Activity 'Creating GIF' -Status 'Complete!'
+                        return
+                    }
+
+                } while ($CKI.Key -ne 'x')
+            }
+        }
+        catch {
+            Write-Error -ErrorRecord $Error[0]
+            exit -1
+        }
+    }
+    end {
+        Write-Verbose -Message 'Captured Active Window successfully'
+        Write-Output $true
+    }
 }

--- a/CaptureIT/Public/Start-ActiveWindowCapture.ps1
+++ b/CaptureIT/Public/Start-ActiveWindowCapture.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Capture the active window
 .DESCRIPTION
@@ -41,49 +41,48 @@ function Start-ActiveWindowCapture {
     )
 
     begin {
-    Write-Verbose -Message 'Starting Active Window Capture'
+        Write-Verbose -Message 'Starting Active Window Capture'
 
-    try {
-        Write-Debug -Message 'Getting ScreenCapture Class'
-        $ScreenCaptureObject = Import-ScreenCaptureClass -ErrorAction Stop
-    }
-    catch {
-        Write-Error -ErrorRecord $Error[0]
-    }
-    }
-    process {
-    $varCount = 1
-    try {
-        if ($pscmdlet.ShouldProcess("Active Window", "Capturing")) {
-            
-            while ($true) {
-                Start-Sleep -Milliseconds $Milliseconds
-
-                Write-Verbose "Taking screenshot of the active window"
-
-                Write-Verbose -Message 'Saving screenshots of the active window'
-                $TempFileLocation = "$env:TEMP\CaptureIT\ScreenCapture$varCount.$ImageType"
-            
-                Write-Verbose -Message "Creating temporary screenshot: $TempFileLocation"
-                New-Item -Path $TempFileLocation -Force | Out-Null
-
-                Write-Verbose "Creating activewindow file: $TempFileLocation"
-                $ScreenCaptureObject.CaptureActiveWindowToFile($TempFileLocation, $ImageType)
-
-                Write-Debug -Message 'Incremeting varCount by 1'
-                $varCount++
-            }
+        try {
+            Write-Debug -Message 'Getting ScreenCapture Class'
+            $ScreenCaptureObject = Import-ScreenCaptureClass -ErrorAction Stop
+        }
+        catch {
+            Write-Error -ErrorRecord $Error[0]
         }
     }
-    catch {
-        Write-Error -ErrorRecord $Error[0]
-        exit -1
-    }
-    }
-    end {
-    Write-Verbose -Message 'Captured Active Window successfully'
-    Write-Output $true
-}                       ConvertTo-Gif -FilePath $script:GifFilePath
+    process {
+        $varCount = 1
+        try {
+            if ($pscmdlet.ShouldProcess("Active Window", "Capturing")) {
+
+                do {
+                    Write-Output "Press the 'x' key to stop capturing."
+
+                    Write-Verbose "Taking screenshot of the active window"
+
+                    Write-Verbose -Message 'Saving screenshots of the active window'
+                    $TempFileLocation = "$env:TEMP\CaptureIT\ScreenCapture$varCount.$ImageType"
+
+                    Write-Verbose -Message "Creating temporary screenshot: $TempFileLocation"
+                    New-Item -Path $TempFileLocation -Force | Out-Null
+
+                    Write-Verbose "Creating activewindow file: $TempFileLocation"
+                    $ScreenCaptureObject.CaptureActiveWindowToFile($TempFileLocation, $ImageType)
+
+                    Write-Debug -Message 'Incremeting varCount by 1'
+                    $varCount++
+
+                    while ([console]::KeyAvailable -eq $false) {
+                        Start-Sleep -Milliseconds 100
+                    }
+
+                    $CKI = [console]::ReadKey($true)
+                    Write-Output "You pressed the $($CKI.Key) key."
+
+                    if ($CKI.Key -eq 'x') {
+                        Write-Progress -Activity 'Creating GIF' -Status 'Creating....'
+                        ConvertTo-Gif -FilePath $script:GifFilePath
                         Write-Progress -Activity 'Creating GIF' -Status 'Complete!'
                         return
                     }

--- a/CaptureIT/Public/Start-ActiveWindowCapture.ps1
+++ b/CaptureIT/Public/Start-ActiveWindowCapture.ps1
@@ -1,4 +1,4 @@
-﻿<#
+<#
 .SYNOPSIS
     Capture the active window
 .DESCRIPTION
@@ -34,8 +34,8 @@ function Start-ActiveWindowCapture {
 
         # Image type to capture
         [Parameter(
-            Mandatory = $False,
-            ValueFromPipelineByPropertyName = $False)]
+            Mandatory = $false,
+            ValueFromPipelineByPropertyName = $true)]
         [ValidateSet('jpeg', 'png')]
         [string]$ImageType = 'png'
     )

--- a/CaptureIT/Public/Start-Capture.ps1
+++ b/CaptureIT/Public/Start-Capture.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Start creating your gif
 .DESCRIPTION
@@ -19,26 +19,26 @@
     DateCreated: 07/07/2018
 #>
 function Start-Capture {
-    [CmdletBinding(DefaultParameterSetName = 'Parameter Set 1',
+    [CmdletBinding(DefaultParameterSetName = 'screen',
         SupportsShouldProcess = $true,
         PositionalBinding = $false,
         HelpUri = '',
         ConfirmImpact = 'Medium')]
     Param (
-        # Screenshot of the entire screen 
+        # Screenshot of the entire screen
         [Parameter(
-            Mandatory = $False,
+            Mandatory = $false,
             ParameterSetName = "screen",
-            ValueFromPipelineByPropertyName = $True)]
+            ValueFromPipelineByPropertyName = $true)]
         [switch]$Screen,
 
-        # Screenshot of the active window 
+        # Screenshot of the active window
         [Parameter(
-            Mandatory = $False,
+            Mandatory = $false,
             ParameterSetName = "window",
-            ValueFromPipelineByPropertyName = $False)]
+            ValueFromPipelineByPropertyName = $true)]
         [switch]$ActiveWindow,
-   
+
         # Milliseconds between screenshot
         [Parameter(
             Mandatory = $false,
@@ -47,8 +47,8 @@ function Start-Capture {
 
         # Name and location to save the generated gif
         [Parameter(
-            Mandatory = $True,
-            ValueFromPipelineByPropertyName = $True)]
+            Mandatory = $true,
+            ValueFromPipelineByPropertyName = $true)]
         [ValidateScript( {
                 if ($_ -notmatch "(\.gif)") {
                     throw "The file specified in the path argument must be type of gif"
@@ -58,7 +58,7 @@ function Start-Capture {
         ]
         [string]$FilePath
     )
-    
+
     $script:GifFilePath = $FilePath
 
     try {
@@ -82,7 +82,7 @@ function Start-Capture {
                 Start-FullScreenCapture -Milliseconds $Milliseconds
             }
             catch {
-                Write-Error -Exception $Error[0]
+                Write-Error -ErrorRecord $Error[0]
                 exit -1
             }
 
@@ -103,7 +103,7 @@ function Start-Capture {
                 Start-ActiveWindowCapture -Milliseconds $Milliseconds
             }
             catch {
-                Write-Error -Exception $Error[0]
+                Write-Error -ErrorRecord $Error[0]
                 exit -1
             }
 

--- a/CaptureIT/Public/Start-Capture.ps1
+++ b/CaptureIT/Public/Start-Capture.ps1
@@ -64,9 +64,9 @@ function Start-Capture {
     try {
         if (Get-ChildItem -Path "$env:TEMP\CaptureIT\" -ErrorAction SilentlyContinue) {
             try {
-                [IO.File]::OpenWrite($file).close(); $true 
+                [IO.File]::OpenWrite($file).close();
             }
-            catch {$false}
+            catch {}
 
             Remove-Item -Path "$env:TEMP\CaptureIT\" -Recurse -Force
         }

--- a/CaptureIT/Public/Start-Capture.ps1
+++ b/CaptureIT/Public/Start-Capture.ps1
@@ -1,4 +1,4 @@
-﻿<#
+<#
 .SYNOPSIS
     Start creating your gif
 .DESCRIPTION
@@ -60,6 +60,20 @@ function Start-Capture {
     )
     
     $script:GifFilePath = $FilePath
+
+    try {
+        if (Get-ChildItem -Path "$env:TEMP\CaptureIT\" -ErrorAction SilentlyContinue) {
+            try {
+                [IO.File]::OpenWrite($file).close(); $true 
+            }
+            catch {$false}
+
+            Remove-Item -Path "$env:TEMP\CaptureIT\" -Recurse -Force
+        }
+    }
+    catch {
+        Write-Error -ErrorRecord $Error[0] -RecommendedAction "Please remove stale screenshots from $env:TEMP\CaptureIT\"
+    }
 
     if ($Screen) {
         if ($pscmdlet.ShouldProcess("Entire Screen", "Begin Capturing")) {

--- a/CaptureIT/Public/Start-FullScreenCapture.ps1
+++ b/CaptureIT/Public/Start-FullScreenCapture.ps1
@@ -53,38 +53,38 @@ function Start-FullScreenCapture {
     try {
         if ($pscmdlet.ShouldProcess("Full Screen", "Capturing")) {
 
-            [console]::TreatControlCAsInput = $true
+            do {
+                Write-Output "Press the 'x' key to stop capturing."
 
-            while ($true) {
-                Write-Progress -Activity 'Full Screen Capture' -Status 'Capturing....'
-                if ([console]::KeyAvailable) {
-                    $key = [system.console]::readkey($true)
-                    if (($key.modifiers -band [consolemodifiers]"control") -and ($key.key -eq "C")) {
+                Write-Verbose "Taking screenshot of the entire screen"
 
-                        Write-Progress -Activity 'Creating GIF' -Status 'Creating....'
-                        ConvertTo-Gif -FilePath $script:GifFilePath
-                        Write-Progress -Activity 'Creating GIF' -Status 'Complete!'
-                        return
-                    }
-                    else {
-                        Start-Sleep -Milliseconds $Milliseconds
-                
-                        Write-Verbose "Taking screenshot of the entire screen"
+                Write-Verbose -Message 'Saving screenshots of the enter screen'
+                $TempFileLocation = "$env:TEMP\CaptureIT\ScreenCapture$varCount.$ImageType"
 
-                        Write-Verbose -Message 'Saving screenshots of the enter screen'
-                        $TempFileLocation = "$env:TEMP\CaptureIT\ScreenCapture$varCount.$ImageType"
+                Write-Verbose -Message "Creating temporary screenshot: $TempFileLocation"
+                New-Item -Path $TempFileLocation -Force | Out-Null
 
-                        Write-Verbose -Message "Creating temporary screenshot: $TempFileLocation"
-                        New-Item -Path $TempFileLocation -Force | Out-Null
+                Write-Verbose "Creating Full Screen file: $TempFileLocation"
+                $ScreenCaptureObject.CaptureScreenToFile($TempFileLocation, ${ImageType})
 
-                        Write-Verbose "Creating Full Screen file: $TempFileLocation"
-                        $ScreenCaptureObject.CaptureScreenToFile($TempFileLocation, ${ImageType})
+                Write-Debug -Message 'Incremeting varCount by 1'
+                $varCount++
 
-                        Write-Debug -Message 'Incremeting varCount by 1'
-                        $varCount++
-                    }
+                while ([console]::KeyAvailable -eq $false) {
+                    Start-Sleep -Milliseconds 100
                 }
-            }
+
+                $CKI = [console]::ReadKey($true)
+                Write-Output "You pressed the $($CKI.Key) key."
+                    
+                if ($CKI.Key -eq 'x') {
+                    Write-Progress -Activity 'Creating GIF' -Status 'Creating....'
+                    ConvertTo-Gif -FilePath $script:GifFilePath
+                    Write-Progress -Activity 'Creating GIF' -Status 'Complete!'
+                    return
+                }
+
+            } while ($CKI.Key -ne 'x')
         }
     }
     catch {

--- a/README.md
+++ b/README.md
@@ -37,12 +37,25 @@ If you would like to capture the active window, you will need to specify the swi
 Start-Capture -ActiveWindow -FilePath "c:\users\msadministrator\Desktop\mynewgif.gif"
 ```
 
+To stop capturing, you need to press `x` in the running console.  If you do not, it will continually repeat back to you the key you entered until you press `x`.
+
+```output
+Press the 'x' key to stop capturing.
+You pressed the A key.
+Press the 'x' key to stop capturing.
+You pressed the H key.
+Press the 'x' key to stop capturing.
+You pressed the D key.
+Press the 'x' key to stop capturing.
+You pressed the X key.
+```
+
 ## Notes
 
 ```yaml
    Name: CaptureIT
    Created by: Josh Rickard (MSAdministrator)
-   Created Date: 07/07/2018 
+   Created Date: 07/07/2018
 ```
 
 Some of this code was borrowed from Boe Prox's Take-Screenshot PowerShell Function.


### PR DESCRIPTION
Revamped the logic of how CaptureIT stops capturing.  You must press `x` to stop the capture process going forward.